### PR TITLE
Allow a schema to be passed directly to config

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -483,7 +483,10 @@ async function generateForSchema(
   config: z.output<typeof schema>["generate"][string]
 ) {
   let schema: GraphQLSchema;
-  if ("introspect" in config.schema) {
+
+  if (config.schema instanceof GraphQLSchema) {
+    schema = config.schema;
+  } else if ("introspect" in config.schema) {
     schema = await loadSchemaFromUrl(config.schema.introspect);
   } else {
     schema = await loadSchemaFromFile(config.schema.sdl);

--- a/packages/cli/src/helpers/config.ts
+++ b/packages/cli/src/helpers/config.ts
@@ -1,11 +1,13 @@
 import { cosmiconfig } from "cosmiconfig";
 import { z } from "zod";
+import { GraphQLSchema } from "graphql";
 
 export const schema = z.object({
   generate: z.record(
     z.string(),
     z.strictObject({
       schema: z.union([
+        z.instanceof(GraphQLSchema),
         z.strictObject({
           sdl: z.string(),
         }),


### PR DESCRIPTION
This PR adds support for passing your schema directly to codegen as an instance of `GraphQLSchema`.

```ts
import { schema } from "../api/src/schema";
import type { GQLBConfig } from "@gqlb/cli";

const config = {
  generate: {
    apollo: {
      schema, // pretty cool
      output: "src/gql",
    },
  },
} satisfies GQLBConfig;
```