### PR TITLE
Make alias a string by default

### DIFF
--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -75,7 +75,7 @@ function makeSelections(
       if (s.selectionSet && s.selectionSet.selections.length > 0) {
         fieldArgs.push(`b => ${makeSelections(s.selectionSet, formatComment)}`);
       }
-      let alias;
+      let alias = "";
       if (s.alias) {
         alias = `.alias("${s.alias.value}")`;
       }


### PR DESCRIPTION
When alias was undefined, it was giving the following error:

```
SyntaxError: ',' expected. (8:11)
   6 |         , b => [
   7 |     //
>  8 |     b.id()undefined
     |           ^
   9 |   ])undefined
  10 |   ]);
  11 |     
```