### PR TITLE
Fragment Masking

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,6 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "ignore": ["@gqlb/test", "@gqlb/website"]
 }

--- a/.changeset/gentle-cheetahs-protect.md
+++ b/.changeset/gentle-cheetahs-protect.md
@@ -1,0 +1,6 @@
+---
+"@gqlb/core": patch
+"@gqlb/cli": patch
+---
+
+Optional fragment masking

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -94,15 +94,6 @@ function methodsForFields(
   const fields = Object.values(fieldMap);
 
   for (const field of fields) {
-    // const ifaceName = `Builder_${name}_field_${field.name}`;
-    // const iface: InterfaceDeclarationStructure = {
-    //   kind: StructureKind.Interface,
-    //   name: ifaceName,
-    //   callSignatures: [],
-    // };
-
-    // builders[field.name] = iface;
-
     const comment: JSDocStructure = {
       kind: StructureKind.JSDoc,
       description: field.description ?? "",

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -301,7 +301,7 @@ function builderFunctionsForInlineFragments(
       typeParameters: [
         {
           name: "Fragment",
-          constraint: "FragmentDefinition<any, any, any>",
+          constraint: "FragmentDefinition",
         },
       ],
       parameters: [
@@ -318,7 +318,7 @@ function builderFunctionsForInlineFragments(
       typeParameters: [
         {
           name: "Fragment",
-          constraint: "FragmentDefinitionWithVariables<any, any, any>",
+          constraint: "FragmentDefinitionWithVariables",
         },
       ],
       parameters: [
@@ -328,7 +328,7 @@ function builderFunctionsForInlineFragments(
         },
         {
           name: "variables",
-          type: "Fragment extends FragmentDefinitionWithVariables<any, any, infer V, any> ? V : never",
+          type: "Fragment extends FragmentDefinitionWithVariables<any, any, any, infer V, any> ? V : never",
         },
       ],
       returnType: `FragmentSpread<Fragment>`,
@@ -805,7 +805,7 @@ async function generateForSchema(
                 type: `(b: Builder_${type.name}) => Result`,
               },
             ],
-            returnType: `FragmentDefinition<${possibleTypes}, "${type.name}", SelectionSetOutput<Result, ${possibleTypes}>>`,
+            returnType: `FragmentDefinition<Name, ${possibleTypes}, "${type.name}", SelectionSetOutput<Result, ${possibleTypes}>>`,
           });
           callSignatures.push({
             kind: StructureKind.CallSignature,
@@ -843,7 +843,7 @@ async function generateForSchema(
                 `,
               },
             ],
-            returnType: `FragmentDefinitionWithVariables<${possibleTypes}, "${type.name}", {
+            returnType: `FragmentDefinitionWithVariables<Name, ${possibleTypes}, "${type.name}", {
               [K in keyof Variables]: AllowNonNullableVariables<ParseVariableDef<Variables[K]>>
             }, SelectionSetOutput<Result, ${possibleTypes}>, {
               [K in keyof Variables]: VariableInput<ParseVariableDef<Variables[K]>>

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -58,13 +58,25 @@ export type FragmentName<
   ? N
   : never;
 
+export type FragmentRefObj<
+  T extends FragmentDefinition | FragmentDefinitionWithVariables,
+> = {
+  readonly [FragmentRefKey]: FragmentName<T>;
+};
+
 export type FragmentRef<
   T extends FragmentDefinition | FragmentDefinitionWithVariables,
-> = OutputOf<T> extends infer U ? U & FragmentRef<T> : never;
+> = FragmentData<T> extends infer U
+  ? IntersectWithFragmentRefUnion<U, FragmentRefObj<T>>
+  : never;
 
 export type FragmentData<
   T extends FragmentDefinition | FragmentDefinitionWithVariables,
-> = OutputOf<T>;
+> = T extends FragmentDefinition<any, any, any, infer O>
+  ? O
+  : T extends FragmentDefinitionWithVariables<any, any, any, any, infer O>
+    ? O
+    : never;
 
 export type FragmentOutput<
   T extends
@@ -74,12 +86,12 @@ export type FragmentOutput<
   PT extends string,
 > = NeverToEmptyObj<
   Extract<
-    SelectionOutput<T> &
-      (T extends FragmentDefinition | FragmentDefinitionWithVariables
-        ? {
-            readonly [FragmentRefKey]: FragmentName<T>;
-          }
-        : never),
+    IntersectWithFragmentRefUnion<
+      SelectionOutput<T>,
+      T extends FragmentDefinition | FragmentDefinitionWithVariables
+        ? FragmentRefObj<T>
+        : {}
+    >,
     { readonly __typename: PT }
   >
 >;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -14,7 +14,6 @@ import {
   SelectionSetNode,
   SelectionNode,
   print,
-  isConstValueNode,
 } from "graphql";
 import { SelectionSetSelection } from "./helpers";
 
@@ -342,6 +341,7 @@ class KeyedCache<T> {
 }
 
 export class FragmentDefinition<
+  const Name extends string = any,
   const PossibleTypes extends string = any,
   const TypeCondition extends string = any,
   const Output = any,
@@ -352,7 +352,7 @@ export class FragmentDefinition<
   private cache = new KeyedCache<TypedDocumentNode<Output, {}>>(undefined);
 
   constructor(
-    public readonly name: string,
+    public readonly name: Name,
     public readonly typeCondition: TypeCondition,
     private selections: ReadonlyArray<SelectionSetSelection>
   ) {
@@ -425,6 +425,7 @@ export class FragmentDefinition<
 }
 
 export class FragmentDefinitionWithVariables<
+  const Name extends string = any,
   const PossibleTypes extends string = any,
   const TypeCondition extends string = any,
   const Variables = any,
@@ -440,7 +441,7 @@ export class FragmentDefinitionWithVariables<
   );
 
   constructor(
-    public readonly name: string,
+    public readonly name: Name,
     public readonly typeCondition: TypeCondition,
     private variables: Record<
       keyof Variables,

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @gqlb/test
-
-## null
-
-### Patch Changes
-
-- @gqlb/core@0.0.4

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -16,6 +16,5 @@
     "perf": "npm run build && node --enable-source-maps ./dist/perf/index.js",
     "build": "tsc",
     "perf:debug": "npm run build && node --enable-source-maps --inspect-brk ./dist/perf/index.js"
-  },
-  "version": null
+  }
 }

--- a/packages/test/src/perf/deep_fragments.perf.ts
+++ b/packages/test/src/perf/deep_fragments.perf.ts
@@ -1,20 +1,20 @@
 import { FragmentDefinition } from "@gqlb/core";
 import { b } from "../generated/test_01/b";
+import { DocumentNode } from "graphql";
 
-
-function makeRecursiveFragment(depth: number): FragmentDefinition {
+function makeRecursiveFragment(depth: number) {
   let lastFragment: null | FragmentDefinition = null;
-  while(depth > 0) {
-    if(lastFragment === null) {
-      lastFragment = b.fragment(`RecursiveFragment_${depth}`, 'User', b => [
+  while (depth > 0) {
+    if (lastFragment === null) {
+      lastFragment = b.fragment(`RecursiveFragment_${depth}`, "User", (b) => [
         //
         b.name(),
       ]);
-    }else {
-      lastFragment = b.fragment(`RecursiveFragment_${depth}`, 'User', b => [
+    } else {
+      lastFragment = b.fragment(`RecursiveFragment_${depth}`, "User", (b) => [
         //
         b.name(),
-        b.__fragment(lastFragment!)
+        b.__fragment(lastFragment!),
       ]);
     }
     depth--;
@@ -24,9 +24,9 @@ function makeRecursiveFragment(depth: number): FragmentDefinition {
 
 export const label = "Deep Fragments";
 
-export default function() {
-  const QUERY = b.query('DeepFragments', b => [
+export default function (): DocumentNode {
+  const QUERY = b.query("DeepFragments", (b) => [
     b.__fragment(makeRecursiveFragment(500)),
-  ])
+  ]);
   return QUERY.document();
 }

--- a/packages/test/src/tests/fragments.test.ts
+++ b/packages/test/src/tests/fragments.test.ts
@@ -18,7 +18,6 @@ describe("Fragments refs", () => {
       ]),
     ]);
     const output = "" as any as OutputOf<typeof q>;
-    type Ref = FragmentRef<typeof f_a>;
     function assertFragmentRef(_: FragmentRef<typeof f_a> | null) {}
     assertFragmentRef(output.user);
   });

--- a/packages/test/src/tests/fragments.test.ts
+++ b/packages/test/src/tests/fragments.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "node:test";
+import { b } from "../generated/test_01/b";
+import { FragmentRef, OutputOf } from "@gqlb/core";
+
+describe("Fragments refs", () => {
+  it("should produce a fragment ref", () => {
+    const f_b = b.fragment("B", "User", (b) => [b.id()]);
+    const f_a = b.fragment("A", "User", (b) => [
+      //
+      b.id(),
+      b.__fragment(f_b),
+    ]);
+    const q = b.query("Q", (b) => [
+      //
+      b.user({ id: "1" }, (b) => [
+        //
+        b.__fragment(f_a),
+      ]),
+    ]);
+    const output = "" as any as OutputOf<typeof q>;
+    type Ref = FragmentRef<typeof f_a>;
+    function assertFragmentRef(_: FragmentRef<typeof f_a> | null) {}
+    assertFragmentRef(output.user);
+  });
+});


### PR DESCRIPTION
Adds the following types:
`FragmentRef<T>`: A reference to a fragment and its data
`FragmentData<T>`: The data of a fragment, with not specific reference (For right now an alias to `OutputOf<T>`)

Changes to types:
`FragmentDefinition` and `FragmentDefinitionWithVariables` now have a new type parameter for their name. Breaking change for everything using type parameters.

Examples:
```ts
const f = b.fragment("UserData, "User", b => [
  b.id(),
  b.name(),
]);

const queryA = b.query("A", b => [
  b.user(b => [
    b.__fragment(f),
  ])
])

const queryB = b.query("A", b => [
  b.user(b => [
    b.id(),
    b.name(),
  ])
])

function ref(ref: FragmentRef<typeof f>) {
  ref.id // <-- Valid. Ref contains fragment data
}
function data(data: FragmentData<typeof f>) {
  ref.id // <-- Valid. Fragment data loaded
}
const aData = // ... load queryA ...

ref(aData.user) // <-- Valid. Fragment refs match and data included
data(aData.user) // <-- Valid. Data matches (fragment refs not checked)

const bData = // ... load queryB ...

ref(bData.user) // <-- Error. Fragment ref does not exist, but data does
data(bData.user) // <-- Valid. Data matches (fragment ref doesn't exist, but it is not checked)
```